### PR TITLE
feature 29351 POC comparison

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -90,6 +90,23 @@ class UserMailer < BaseMailer
     end
   end
 
+  def work_package_unblocked(work_package, user, wp_unblocker)
+    User.execute_as user do
+      @issue = work_package
+      @wp_unblocker = wp_unblocker
+      @preceding_issues = WorkPackage.find(
+        (work_package.follow_ids + work_package.blocked_by_ids).uniq
+      )
+      set_work_package_headers(work_package)
+      message_id work_package, user
+      references work_package, user
+
+      with_locale_for(user) do
+        mail to: user.mail, subject: subject_for_work_package(work_package)
+      end
+    end
+  end
+
   def password_lost(token)
     return unless token.user # token's can have no user
 

--- a/app/views/user_mailer/work_package_unblocked.html.erb
+++ b/app/views/user_mailer/work_package_unblocked.html.erb
@@ -1,0 +1,44 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2020 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See docs/COPYRIGHT.rdoc for more details.
+
+++#%>
+<%= t("text_work_package_unblocked", id: "##{@issue.id}", wp_unblocker: @wp_unblocker) %>
+<hr />
+<%= render partial: 'issue_details', locals: { issue: @issue } %>
+<p>
+  <%= format_text(t(:text_latest_note, note: last_issue_note(@issue)),
+                    only_path: false,
+                    object: @issue,
+                    project: @issue.project) %>
+</p>
+<hr />
+<%= t("text_work_package_preceding_issues") %>
+<ul>
+<% @preceding_issues.each do |preceding| %>
+  <li><%= link_to preceding.to_s, work_package_url(preceding) %></li>
+<% end %>
+</ul>

--- a/app/views/user_mailer/work_package_unblocked.text.erb
+++ b/app/views/user_mailer/work_package_unblocked.text.erb
@@ -1,0 +1,39 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) 2012-2020 the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See docs/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<%= t("text_work_package_unblocked", id: "##{@issue.id}", wp_unblocker: @wp_unblocker) %>
+
+----------------------------------------
+<%= render partial: 'issue_details', locals: { issue: @issue } %>
+<%= t(:text_latest_note, note: last_issue_note(@issue)) %>
+
+<%= t("text_work_package_preceding_issues") %>
+<% @preceding_issues.each do |preceding| %>
+  <%= work_package_url(preceding) %>
+<% end %>

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -29,11 +29,11 @@
 #++
 
 OpenProject::Notifications.subscribe('journal_created') do |payload|
-  Services::UnblockFollowingWorkPackages.new(payload[:journal]).run
   Notifications::JournalNotificationService.call(payload[:journal], payload[:send_notification])
 end
 
 OpenProject::Notifications.subscribe(OpenProject::Events::AGGREGATED_WORK_PACKAGE_JOURNAL_READY) do |payload|
+  Services::UnblockFollowingWorkPackages.new(payload[:journal]).run
   Notifications::JournalWpMailService.call(payload[:journal], payload[:send_mail])
 end
 

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -43,3 +43,11 @@ end
 OpenProject::Notifications.subscribe('watcher_removed') do |payload|
   WatcherRemovedNotificationMailer.handle_watcher(payload[:watcher], payload[:watcher_remover])
 end
+
+OpenProject::Notifications.subscribe(OpenProject::Events::WORK_PACKAGE_UNBLOCKED) do |payload|
+  # Here I'm calling a new "WorkPackageUnblockedNotificationMailer", unless we can work the
+  # notification into the existing journaled WP notification mailer
+  puts "######################"
+  puts "Notification that a work package is unblocked: #{ payload[:work_package].subject }"
+  puts "######################"
+end

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -46,8 +46,5 @@ OpenProject::Notifications.subscribe('watcher_removed') do |payload|
 end
 
 OpenProject::Notifications.subscribe(OpenProject::Events::WORK_PACKAGE_UNBLOCKED) do |payload|
-  puts "######################"
-  puts "Notification that a work package is unblocked: #{ payload[:work_package].subject }"
-  puts "######################"
   WorkPackageUnblockedNotificationMailer.handle_unblock(payload[:work_package], payload[:wp_unblocker])
 end

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -29,6 +29,7 @@
 #++
 
 OpenProject::Notifications.subscribe('journal_created') do |payload|
+  Services::UnblockFollowingWorkPackages.new(payload[:journal]).run
   Notifications::JournalNotificationService.call(payload[:journal], payload[:send_notification])
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1818,8 +1818,8 @@ en:
   mail_body_register_header_title: "Project member invitation email"
   mail_body_register_user: "Dear %{name}, "
   mail_body_register_links_html: |
-    Please feel free to browse our youtube channel (%{youtube_link}) where we provide a webinar (%{webinar_link}) 
-    and “Get started” videos (%{get_started_link}) to make your first steps in OpenProject as easy as possible. 
+    Please feel free to browse our youtube channel (%{youtube_link}) where we provide a webinar (%{webinar_link})
+    and “Get started” videos (%{get_started_link}) to make your first steps in OpenProject as easy as possible.
     <br />
     If you have any further questions, consult our documentation (%{documentation_link}) or contact us (%{contact_us_link}).
   mail_body_register_closing: "Your OpenProject team"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2363,6 +2363,8 @@ en:
   text_work_package_category_destroy_question: "Some work packages (%{count}) are assigned to this category. What do you want to do?"
   text_work_package_category_reassign_to: "Reassign work packages to this category"
   text_work_package_updated: "Work package %{id} has been updated by %{author}."
+  text_work_package_unblocked: "Work package %{id} has been unblocked by %{wp_unblocker}."
+  text_work_package_preceding_issues: "The preceding issue(s) can be found here"
   text_work_package_watcher_added: "You have been added as a watcher to Work package %{id} by %{watcher_changer}."
   text_work_package_watcher_removed: "You have been removed from watchers of Work package %{id} by %{watcher_changer}."
   text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"

--- a/lib/api/v3/work_packages/update_end_point.rb
+++ b/lib/api/v3/work_packages/update_end_point.rb
@@ -3,9 +3,6 @@ module API
     module WorkPackages
       class UpdateEndPoint < API::V3::Utilities::Endpoints::Update
         def present_success(current_user, call)
-          work_package = WorkPackage.find(call.result['id'])
-          Services::UnblockFollowingWorkPackages.new(work_package, current_user).run
-
           call.result.reload
 
           super

--- a/lib/api/v3/work_packages/update_end_point.rb
+++ b/lib/api/v3/work_packages/update_end_point.rb
@@ -3,6 +3,9 @@ module API
     module WorkPackages
       class UpdateEndPoint < API::V3::Utilities::Endpoints::Update
         def present_success(current_user, call)
+          work_package = WorkPackage.find(call.result['id'])
+          Services::UnblockFollowingWorkPackages.new(work_package, current_user).run
+
           call.result.reload
 
           super

--- a/lib/open_project/events.rb
+++ b/lib/open_project/events.rb
@@ -38,6 +38,7 @@ module OpenProject
   # @see OpenProject::Notifications
   module Events
     AGGREGATED_WORK_PACKAGE_JOURNAL_READY = "aggregated_work_package_journal_ready".freeze
+    WORK_PACKAGE_UNBLOCKED = "work_package_unblocked".freeze
     NEW_TIME_ENTRY_CREATED = "new_time_entry_created".freeze
 
     PROJECT_CREATED = "project_created".freeze

--- a/lib/services/unblock_following_work_packages.rb
+++ b/lib/services/unblock_following_work_packages.rb
@@ -43,7 +43,9 @@ class Services::UnblockFollowingWorkPackages
     return if @journal.get_changes["status_id"].first.in? @closed_status_ids
     return unless @journal.get_changes["status_id"].last.in? @closed_status_ids
     # We want to consider both follow/precede and blocks/blocked-by relations
-    dependents = (@work_package.precedes.with_status_open + WorkPackage.find(@work_package.block_ids)).uniq
+    dependents = WorkPackage.with_status_open.find(
+      (@work_package.precede_ids + @work_package.block_ids).uniq
+    )
     dependents.each do |dependent|
       unless dependent.follows.with_status_open.any?
         OpenProject::Notifications.send(OpenProject::Events::WORK_PACKAGE_UNBLOCKED,

--- a/lib/services/unblock_following_work_packages.rb
+++ b/lib/services/unblock_following_work_packages.rb
@@ -27,14 +27,24 @@
 #++
 
 class Services::UnblockFollowingWorkPackages
-  def initialize(work_package, user)
-    @work_package = work_package
-    @user = user
+  def initialize(journal)
+    @journal = journal
+    @work_package = WorkPackage.find(@journal.journable_id)
+    @user = User.find(journal.user_id)
+    @closed_status_ids = Status.where(is_closed: true).pluck(:id)
   end
 
+  # Journal events can be triggered for many reasons, so we return early in many cases:
+  # if status wasn't updated
+  # if the current status is closed (e.g. changing from closed to rejected)
+  # if the new status is not closed
   def run()
-    return unless @work_package.closed?
-    @work_package.precedes.with_status_open.each do |dependent|
+    return unless @journal.get_changes.has_key? "status_id"
+    return if @journal.get_changes["status_id"].first.in? @closed_status_ids
+    return unless @journal.get_changes["status_id"].last.in? @closed_status_ids
+    # We want to consider both follow/precede and blocks/blocked-by relations
+    dependents = (@work_package.precedes.with_status_open + WorkPackage.find(@work_package.block_ids)).uniq
+    dependents.each do |dependent|
       unless dependent.follows.with_status_open.any?
         OpenProject::Notifications.send(OpenProject::Events::WORK_PACKAGE_UNBLOCKED,
                                         work_package: dependent,

--- a/lib/services/unblock_following_work_packages.rb
+++ b/lib/services/unblock_following_work_packages.rb
@@ -47,11 +47,11 @@ class Services::UnblockFollowingWorkPackages
       (@work_package.precede_ids + @work_package.block_ids).uniq
     )
     dependents.each do |dependent|
-      unless dependent.follows.with_status_open.any?
-        OpenProject::Notifications.send(OpenProject::Events::WORK_PACKAGE_UNBLOCKED,
-                                        work_package: dependent,
-                                        wp_unblocker: @user)
-      end
+      next if dependent.follows.with_status_open.any?
+      next if dependent.blocked_by.with_status_open.any?
+      OpenProject::Notifications.send(OpenProject::Events::WORK_PACKAGE_UNBLOCKED,
+                                      work_package: dependent,
+                                      wp_unblocker: @user)
     end
   end
 end


### PR DESCRIPTION
The logic is roughly as follows:
- On every WP status change the UnblockFollowingWorkPackages service is called
- The service returns early if the new status isn't meta "closed"
- The service checks each WP which follow the closed WP, and creates a "WORK_PACKAGE_UNBLOCKED" event for any open WP where all it's preceding WP's are closed.
- A listener is subscribed to the "WORK_PACKAGE_UNBLOCKED" event, currently printing dummy text to STDOUT to make debugging easy

I've stuck with "unblocked" naming for all code changes on this feature, but it clashes with existing blocked terminology, so I'd prefer to rename all the cases of "unblocked" in the code with whatever new term is deemed better.
